### PR TITLE
Skip broken keys when cleaning up expired channels

### DIFF
--- a/firechannel/channel.py
+++ b/firechannel/channel.py
@@ -160,6 +160,10 @@ def find_all_expired_channels(max_age=3600, firebase_client=None):
     cutoff = (time.time() - max_age) * 1000
     channels = client.get("firechannels.json") or {}
     for client_id, channel in channels.items():
+        if not isinstance(channel, dict):
+            yield client_id
+            continue
+
         timestamp = channel.get("timestamp", 0)
         if timestamp <= cutoff:
             yield client_id


### PR DESCRIPTION
In the event that something stupid gets written to `firechannels.json`, cleaning up expired channels will explode since the function assumes all the values there will be dictionaries. This makes it so that keys with invalid values (e.g. `message`) get cleaned up as well rather than blowing everything up.