### PR TITLE
Replace oauth2client with google-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ for channel_id in expired_channels:
 
 ## Testing
 
-To run the tests, create a service account and point an env var called
-`SERVICE_KEY_FILE_PATH` to it and another one called `FIREBASE_PROJECT`
-to the name of your project.  Finally, run `py.test`.
+To run the tests, create a service account and point an env var
+called `GOOGLE_APPLICATION_CREDENTIALS` to it and another one called
+`FIREBASE_PROJECT` to the name of your project. Finally, run `py.test`.
 
 ### GAE tests
 
@@ -111,6 +111,6 @@ Please read [our contributor's guide](./CONTRIBUTING.md).
 
 [setup]: https://console.firebase.google.com/project/_/overview
 [rules]: https://console.firebase.google.com/project/_/database/rules
-[leadpages]: http://leadpages.net
-[careers]: http://www.leadpages.net/careers
+[leadpages]: https://leadpages.com
+[careers]: https://www.leadpages.com/careers
 [contributors]: https://github.com/leadpages/gcloud_requests/graphs/contributors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.18.4,<3.0
-oauth2client>=1.5.2,<2.0
+google-auth>=1.0,<2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,9 @@ logging.basicConfig(level=logging.DEBUG)
 
 @pytest.fixture(scope="session")
 def credentials():
-    key_file_path = os.getenv("SERVICE_KEY_FILE_PATH")
-    assert key_file_path, "SERVICE_KEY_FILE_PATH must be set"
-    return get_credentials(key_file_path)
+    key_file_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    assert key_file_path, "GOOGLE_APPLICATION_CREDENTIALS must be set"
+    return get_credentials()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_firebase.py
+++ b/tests/test_firebase.py
@@ -8,12 +8,21 @@ from mock import Mock, patch
 def test_firebase_client_retries_failed_access_tokens(request_mock, client):
     # Given that I have a firebase client
     # And I've mocked the Session.request to fail with a 401 error
-    request_mock.return_value = Mock(status_code=401, text="Unauthorized request.")
+    request_mock.return_value = Mock(
+        status_code=401,
+        content=b'{"error":"unauthorized_request"}',
+        text='{"error":"unauthorized_request"}',
+    )
 
     # If I make a request
     # I expect a BadRequest error to be raised
     with pytest.raises(BadRequest):
         client.get("firechannels.json")
 
-    # And request to have been called 3 times
-    assert len(request_mock.mock_calls) == 3
+    # And request to have been called 6 times
+    request_count_by_method = [m.args[0] for m in request_mock.mock_calls]
+    assert len(request_count_by_method) == 6
+    # 3 times for each firebase request
+    assert request_count_by_method.count("GET") == 3
+    # And 3 times for the requests to refresh auth tokens.
+    assert request_count_by_method.count("POST") == 3

--- a/tests_appengine/conftest.py
+++ b/tests_appengine/conftest.py
@@ -1,12 +1,12 @@
-import pytest
 import os
 import sys
+
+import pytest
+from mock import patch
 
 appengine_path = os.getenv("APPENGINE_SDK_PATH")
 assert appengine_path, "APPENGINE_SDK_PATH must be set, i.e. google-cloud-sdk/platform/google_appengine"
 sys.path.append(appengine_path)
-# We must also include vendored depende
-# sys.path.append(os.path.join(appengine_path, "lib"))
 
 # The 'google' package has modules we need in both the SDK path
 # and the site-packages dir. Here we'll add the SDK path to the
@@ -16,7 +16,9 @@ sys.modules["google"].__path__.append(
     os.path.join(appengine_path, "google"),
 )
 
+from firechannel.credentials import SCOPES  # noqa
 from google.appengine.ext import testbed  # noqa
+import google.auth.app_engine  # noqa
 
 
 @pytest.fixture(autouse=True)
@@ -28,3 +30,15 @@ def appengine_testbed():
     tb.init_memcache_stub()
     yield tb
     tb.deactivate()
+
+
+@pytest.fixture
+def credentials():
+    return google.auth.app_engine.Credentials(scopes=SCOPES)
+
+
+@pytest.fixture(autouse=True)
+def mock_get_credentials(credentials):
+    with patch("google.auth.default", ) as mock_get_credentials:
+        mock_get_credentials.return_value = (credentials, "unittest-firechannel")
+        yield mock_get_credentials

--- a/tests_appengine/conftest.py
+++ b/tests_appengine/conftest.py
@@ -3,9 +3,18 @@ import os
 import sys
 
 appengine_path = os.getenv("APPENGINE_SDK_PATH")
-assert appengine_path, "APPENGINE_SDK_PATH must be set"
-sys.path.append(os.path.join(appengine_path, "python"))
+assert appengine_path, "APPENGINE_SDK_PATH must be set, i.e. google-cloud-sdk/platform/google_appengine"
+sys.path.append(appengine_path)
+# We must also include vendored depende
+# sys.path.append(os.path.join(appengine_path, "lib"))
 
+# The 'google' package has modules we need in both the SDK path
+# and the site-packages dir. Here we'll add the SDK path to the
+# search paths so `google.appengine` can resolve.
+import google  # noqa
+sys.modules["google"].__path__.append(
+    os.path.join(appengine_path, "google"),
+)
 
 from google.appengine.ext import testbed  # noqa
 

--- a/tests_appengine/test_client.py
+++ b/tests_appengine/test_client.py
@@ -20,8 +20,8 @@ def test_can_refresh_access_tokens():
     # Given that I've got a testbed and a client
     client = get_client()
 
-    # If I delete its access token
-    del client.access_token
+    # If I remove the auth token from Credentials
+    client.credentials.token = None
 
     # I expect the underlying credentials to be refreshed
-    assert client.credentials.access_token
+    assert client.access_token

--- a/tests_appengine/test_credentials.py
+++ b/tests_appengine/test_credentials.py
@@ -1,17 +1,8 @@
-from firechannel import get_credentials
 from firechannel.credentials import build_token, decode_token
-from google.auth.app_engine import Credentials
 
 
-def test_can_build_appengine_credentials():
-    # Given that I've got a testbed
-    # If I try to get credentials, I expect to get back AppAssertionCredentials
-    assert isinstance(get_credentials(), Credentials)
-
-
-def test_can_build_and_decode_tokens():
-    # Given that I've got a testbed and some credentials
-    credentials = get_credentials()
+def test_can_build_and_decode_tokens(credentials):
+    # Given that I've got a testbed and some GAE credentials
 
     # If I attempt to build a token
     params = {"uid": "hello"}

--- a/tests_appengine/test_credentials.py
+++ b/tests_appengine/test_credentials.py
@@ -1,12 +1,12 @@
 from firechannel import get_credentials
 from firechannel.credentials import build_token, decode_token
-from oauth2client.appengine import AppAssertionCredentials
+from google.auth.app_engine import Credentials
 
 
 def test_can_build_appengine_credentials():
     # Given that I've got a testbed
     # If I try to get credentials, I expect to get back AppAssertionCredentials
-    assert isinstance(get_credentials(), AppAssertionCredentials)
+    assert isinstance(get_credentials(), Credentials)
 
 
 def test_can_build_and_decode_tokens():


### PR DESCRIPTION
[oauth2client is now deprecated](https://pypi.org/project/oauth2client/), and the new lib to
replace this is `google-auth`.

This switches to using the `google.auth.credentials.Credentials` API for
management of credential lifetimes, with exception to keeping the mutex
during a `refresh()` operation. I didn't see anything obvious in the new
API that had that, and it feels like a good behavior to preserve.

Most tests passed without modification. There's one new conflict for the
`google` module between the GAE SDK provided packages and google-auth
package from pypi. The pytest setup now just injects the GAE SDK path
into the `google` module so those imports can resolve.

Instead of having `get_credentials()` conditionally resolve based on
GAE lib presence, this opts for using `google.auth.default()` to fetch
credentials everywhere. To protect against further runtime errors an
assertion is added that the returned credentials implements the Signing
methods as we now depend on that for issuer identification and actual
signing of the messages.

To keep backwards-compatibility this retains the
`get_appengine_credentials` and the `get_service_key_credentials`
methods.

I tested this on a GAE deploy without any issues.